### PR TITLE
Add travis-ci and appveyor configuration files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: cpp
+
+os:
+  - linux
+  - osx
+
+branches:
+  only:
+    - master
+
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew upgrade; fi
+
+install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install build-essential cmake gettext git-core gpsd gpsd-clients libgps-dev wx-common libwxgtk3.0-dev libglu1-mesa-dev libgtk2.0-dev wx3.0-headers libbz2-dev libtinyxml-dev libportaudio2 portaudio19-dev libcurl4-openssl-dev libexpat1-dev libcairo2-dev libarchive-dev liblzma-dev libexif-dev; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install cairo libexif libarchive wxmac; export PATH="/usr/local/opt/gettext/bin:$PATH";  echo 'export PATH="/usr/local/opt/gettext/bin:$PATH"' >> ~/.bash_profile; fi
+script:
+  - mkdir -p build
+  - cd build
+  - cmake ..
+  - make

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,49 @@
+version: 4.927.{build}
+
+clone_folder: c:\projects\radar_pi
+shallow_clone: true
+image:
+- Visual Studio 2015
+
+platform:
+  - Win32
+
+configuration: Release
+test: OFF
+
+install:
+  - '"C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x86'
+
+  # sent environment variables for wxWidgets
+  - set WXPARENT=C:\
+  - set WXWIN=C:\wxWidgets-3.0.2
+  - set wxWidgets_ROOT_DIR=%WXWIN%
+  - set wxWidgets_LIB_DIR=%WXWIN%\lib\vc_dll
+  - cmd: SET PATH=%PATH%;%WXWIN%;%wxWidgets_LIB_DIR%;C:\Program Files (x86)\Poedit\Gettexttools\bin;
+
+  # install dependencies:
+  - choco install poedit nsis -x86
+
+  # Download and unzip wxwidgets
+  - ps: Start-FileDownload http://downloads.sourceforge.net/project/opencpnplugins/opencpn_packaging_data/wxWidgets-3.0.2.7z
+  - cmd: 7z x wxwidgets-3.0.2.7z -o%WXPARENT% > null
+
+  # some debugging information
+  - set
+
+before_build:
+  - cd c:\projects\radar_pi
+  - mkdir build
+  - cd build
+  - ps: Start-FileDownload http://downloads.sourceforge.net/project/opencpnplugins/opencpn_packaging_data/OpenCPN_buildwin.7z
+  - cmd: 7z x -y OpenCPN_buildwin.7z -oc:\projects\radar_pi
+  - ps: Start-FileDownload http://downloads.sourceforge.net/project/opencpnplugins/opencpn_lib/4.8.2-vc120_xp/opencpn.lib
+  - cmake -T v120_xp ..
+
+build_script:
+  - cmake --build . --config Release --target package
+
+artifacts:
+  - path: build\radar_pi*.exe
+    name: installer
+


### PR DESCRIPTION
Adding configuration for Travis and Appveyor CI platforms
- As configured, the Windows installer artifact may be used with the official OpenCPN builds > 4.8.0 (Which if I remember correctly is the lowest version with fixes important for radar_pi anyway)
- To generate as little load as possible on the overloaded travis-ci macOS infrastructure, the build is performed against wxmac from homebrew and as such the result is not compatible with the official OpenCPN binaries - if you would like to use these builds for official releases, we would have to bundle our own wxWidgets tarball as required by the official Lion-compatible OpenCPN builds.