### PR TITLE
Added ARM64 as package option in cmake

### DIFF
--- a/cmake/PluginPackage.cmake
+++ b/cmake/PluginPackage.cmake
@@ -80,7 +80,11 @@ IF(UNIX AND NOT APPLE)
 
 
   IF (CMAKE_SYSTEM_PROCESSOR MATCHES "arm*")
-    SET (ARCH "armhf")
+    IF (CMAKE_SIZEOF_VOID_P MATCHES "8")
+      SET (ARCH "arm64")
+    ELSE ()
+      SET (ARCH "armhf")
+    ENDIF ()
     # don't bother with rpm on armhf
     SET(CPACK_GENERATOR "DEB;RPM;TBZ2")
   ELSE ()


### PR DESCRIPTION
When making a package make sure the right architecture is used when compling for arm64.
modified: cmake/PluginPackage.cmake

Pretty straightforward.