### PR TITLE
Ci: Cleanup and simplify

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,13 +8,6 @@ jobs:
        - OCPN_TARGET:  xenial
      steps:
        - checkout
-       - run: >
-           echo "deb-src http://us.archive.ubuntu.com/ubuntu/ xenial main"
-           | sudo tee -a /etc/apt/sources.list
-       - run: >
-           echo "deb-src http://us.archive.ubuntu.com/ubuntu/ xenial-updates main"
-           | sudo tee -a /etc/apt/sources.list
-       - run: cat /etc/apt/sources.list
        - run: ci/circleci-build-debian.sh
        - run: ci/circleci-upload.sh
    build-bionic:
@@ -24,13 +17,6 @@ jobs:
        - OCPN_TARGET:  bionic
      steps:
        - checkout
-       - run: >
-           echo "deb-src http://us.archive.ubuntu.com/ubuntu/ bionic main"
-           | sudo tee -a /etc/apt/sources.list
-       - run: >
-           echo "deb-src http://us.archive.ubuntu.com/ubuntu/ bionic-updates main"
-           | sudo tee -a /etc/apt/sources.list
-       - run: cat /etc/apt/sources.list
        - run: ci/circleci-build-debian.sh
        - run: ci/circleci-upload.sh
    build-focal:
@@ -40,13 +26,6 @@ jobs:
        - OCPN_TARGET:  focal
      steps:
        - checkout
-       - run: >
-           echo "deb-src http://us.archive.ubuntu.com/ubuntu/ focal main"
-           | sudo tee -a /etc/apt/sources.list
-       - run: >
-           echo "deb-src http://us.archive.ubuntu.com/ubuntu/ focal-updates main"
-           | sudo tee -a /etc/apt/sources.list
-       - run: cat /etc/apt/sources.list
        - run: ci/circleci-build-debian.sh
        - run: ci/circleci-upload.sh
    build-buster:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,16 +46,6 @@ jobs:
        - checkout
        - run: ci/circleci-build-flatpak.sh
        - run: ci/circleci-upload.sh
-   build-fedora:
-     docker:
-         - image: fedora:29
-     environment:
-       - OCPN_TARGET:  fedora
-     steps:
-       - run: su -c "dnf install -q -y git openssh-clients openssh-server"
-       - checkout
-       - run: ci/circleci-build-fedora.sh
-       - run: ci/circleci-upload.sh
    build-mingw:
      docker:
          - image: fedora:29
@@ -97,10 +87,6 @@ workflows:
             branches:
               only: ci
       - build-flatpak:
-          filters:
-            branches:
-              only: ci
-      - build-fedora:
           filters:
             branches:
               only: ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,42 +1,37 @@
 ---
-version: 2
+version: 2.1
+
+debian-steps: &debian-steps
+  steps:
+    - checkout
+    - run: ci/circleci-build-debian.sh
+    - run: ci/circleci-upload.sh
+
 jobs:
    build-xenial:
      docker:
        - image: circleci/buildpack-deps:xenial-scm
      environment:
        - OCPN_TARGET:  xenial
-     steps:
-       - checkout
-       - run: ci/circleci-build-debian.sh
-       - run: ci/circleci-upload.sh
+     <<: *debian-steps
    build-bionic:
      docker:
        - image: circleci/buildpack-deps:bionic-scm
      environment:
        - OCPN_TARGET:  bionic
-     steps:
-       - checkout
-       - run: ci/circleci-build-debian.sh
-       - run: ci/circleci-upload.sh
+     <<: *debian-steps
    build-focal:
      docker:
        - image: circleci/buildpack-deps:focal-scm
      environment:
        - OCPN_TARGET:  focal
-     steps:
-       - checkout
-       - run: ci/circleci-build-debian.sh
-       - run: ci/circleci-upload.sh
+     <<: *debian-steps
    build-buster:
      docker:
        - image: circleci/buildpack-deps:buster-scm
      environment:
        - OCPN_TARGET:  buster
-     steps:
-       - checkout
-       - run: ci/circleci-build-debian.sh
-       - run: ci/circleci-upload.sh
+     <<: *debian-steps
    build-flatpak:
      machine:
        image: circleci/classic:201808-01
@@ -66,35 +61,27 @@ jobs:
        - run: ci/circleci-build-macos.sh
        - run: ci/circleci-upload.sh
 
+std-filters: &std-filters
+  filters:
+    branches:
+      only:
+        - ci
+
 workflows:
   version: 2
   build_all:
     jobs:
       - build-buster:
-          filters:
-            branches:
-              only: ci
+          <<: *std-filters
       - build-xenial:
-          filters:
-            branches:
-              only: ci
+          <<: *std-filters
       - build-bionic:
-          filters:
-            branches:
-              only: ci
+          <<: *std-filters
       - build-focal:
-          filters:
-            branches:
-              only: ci
+          <<: *std-filters
       - build-flatpak:
-          filters:
-            branches:
-              only: ci
+          <<: *std-filters
       - build-macos:
-          filters:
-            branches:
-              only: ci
+          <<: *std-filters
       - build-mingw:
-          filters:
-            branches:
-              only: ci
+          <<: *std-filters


### PR DESCRIPTION
The .circleci/config file contains cruft which never should have been there. I am the author and sole responsible for this which was copied around before I had time to clean up things. Trying fix it here instead,

Also, circleci supports yaml anchors these days which makes it possible to apply some DRY thinking to the config file.

All in all, the changes here should makes the config file considerable shorter and easier to maintain. It also removes some cycles from the too long build.

The repo at https://github.com/Rasbats/shipdriver_pi contains more updares to the ci builds, notably optimizations of the slow flatpak and macos builds. Here is also support for pushing the metadata files directly to a git repo, simplifying the process to create a PR against the plugins project. Just let me know if you are interested, in which case I will try to transplant these changes to radar_pi in a new PR

EDIT: /slow builds/s/mingw/macos/