### PR TITLE
Fix local windows build failure (#162).

### DIFF
--- a/buildwin/win_deps.bat
+++ b/buildwin/win_deps.bat
@@ -31,3 +31,4 @@ if not exist "C:\Program Files (x86)\Poedit" (
   choco install -y  poedit
 )
 SET PATH=%PATH%;C:\Program Files (x86)\Poedit\Gettexttools\bin
+SET PATH=%PATH%;C:\Program Files (x86)\Poedit


### PR DESCRIPTION
Add missing path to gettext libraries.

It is unclear why this is needed. Perhaps earlier testing has had this path element in place for other reason, perhaps the poedit package layout has changed. In any case, the patch should no be harmful besides taking some precious space in %PATH%

EDIT: Closes: #162