### PR TITLE
ci: Add arm64 flatpak build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,18 +11,6 @@ debian-steps: &debian-steps
 
 jobs:
 
-  # build-mingw:
-  #   machine:
-  #     image: circleci/classic:201808-01
-  #   environment:
-  #     - OCPN_TARGET: mingw
-  #   steps:
-  #     - checkout
-  #     - run: ci/circleci-build-mingw.sh
-  #     - run: cd build; /bin/bash < upload.sh
-  #     - run: python3 ci/git-push
-  #   Disabled, but visible (FTBFS bugs). FIXME
-  #
   build-flatpak-arm64:
     machine:
       image: ubuntu-2004:202101-01
@@ -49,6 +37,7 @@ jobs:
     environment:
       - OCPN_TARGET: flatpak
       - FLATPAK_BRANCH: stable
+      - USE_CUSTOM_PPA: yes
     steps:
       - checkout
       - restore_cache:
@@ -138,6 +127,9 @@ workflows:
   version: 2
   build_all:
     jobs:
+      - build-flatpak-arm64:
+          <<: *std-filters
+
       - build-flatpak:
           <<: *std-filters
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,12 +22,33 @@ jobs:
   #     - run: cd build; /bin/bash < upload.sh
   #     - run: python3 ci/git-push
   #   Disabled, but visible (FTBFS bugs). FIXME
-
+  #
+  build-flatpak-arm64:
+    machine:
+      image: ubuntu-2004:202101-01
+    resource_class: arm.medium
+    environment:
+      - OCPN_TARGET: flatpak-arm64
+      - FLATPAK_BRANCH: beta
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - fp-a64-v1-{{ checksum "ci/circleci-build-flatpak.sh" }}
+      - run: ci/circleci-build-flatpak.sh
+      - save_cache:
+          key: fp-a64-v1-{{ checksum "ci/circleci-build-flatpak.sh" }}
+          paths:
+            - /home/circleci/.local/share/flatpak/repo
+      - run: cd build; /bin/bash < upload.sh
+      - run: python3 ci/git-push
+ 
   build-flatpak:
     machine:
       image: ubuntu-1604:201903-01
     environment:
       - OCPN_TARGET: flatpak
+      - FLATPAK_BRANCH: stable
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
Add an arm64 flatpak build using circleci.

While arm64 still is a somewhat new platform, providing a flatpak build in an early stage should decrease the pressure to build Debian, Ubuntu, Raspbian and what not arm64 plugins.

See: https://github.com/OpenCPN/OpenCPN/issues/2178

EDIT: While on it, drop the mingw build which has been dropped also in main OpenCPN