### PR TITLE
Restore build deps

### DIFF
--- a/build-deps/control
+++ b/build-deps/control
@@ -1,0 +1,29 @@
+Source: opencpn
+Build-Depends: debhelper (>= 9),
+ base-files (>>8) | mesa-common-dev,
+ base-files (>>8) | libgl1-mesa-dev,
+ libgtk2.0-dev,
+ libjsoncpp-dev,
+ libtinyxml-dev,
+ libunarr-dev | base-files (<< 11),
+ libwxgtk3.0-dev | libwxgtk3.0-gtk3-dev,
+ libwxgtk3.0-0v5 | libwxgtk3.0-0 | libwxgtk3.0-gtk3-0v5,
+ libwxgtk3.0-gtk3-dev | base-files (<< 10),
+ libwxgtk-webview3.0-dev | libwxgtk-webview3.0-gtk3-dev | base-files (<< 11),
+ libwxsvg-dev | base-files (<< 11),
+ python3-pip,
+ python3-setuptools,
+ python3-wheel
+
+Standards-Version: 4.3.0
+Homepage: https://opencpn.org
+
+Description: Packages needed to build opencpn on debian.
+ The Build-Depends field can be used to install dependencies
+ using something like:
+ .
+ .   sudo apt install devscripts equivs
+ .   sudo mk-build-deps --install ci/control
+ .
+ These packages are available in trusty+. The base-files
+ fallback is for optional packages available in later releases.

--- a/build-deps/control-raspbian
+++ b/build-deps/control-raspbian
@@ -1,0 +1,24 @@
+Source: opencpn
+Build-Depends: debhelper (>= 9),
+ build-essential,
+ file,
+ gettext,
+ git,
+ libgtk2.0-dev,
+ libjsoncpp-dev,
+ libtinyxml-dev,
+ libwxgtk3.0-dev,
+ lsb-release,
+ wget,
+ wx-common
+
+Standards-Version: 4.3.0
+Homepage: https://opencpn.org
+
+Description: Packages needed to build plugin on raspbian.
+ The Build-Depends field can be used to install dependencies
+ using something like:
+ .
+ .   sudo apt install devscripts equivs
+ .   sudo mk-build-deps -ir ci/control-raspbian
+ .   sudo apt-get -q --allow-unauthenticated install -f

--- a/build-deps/macos-deps
+++ b/build-deps/macos-deps
@@ -1,0 +1,6 @@
+# brew packages installed in macos ci build
+cmake
+gettext
+libexif
+python
+wget

--- a/build-deps/opencpn-deps.spec
+++ b/build-deps/opencpn-deps.spec
@@ -1,0 +1,54 @@
+Name:		opencpn-plugin-deps
+Version:	0.1
+Release:	1%{?dist}
+Summary:	Empty package with opencpn plugin build dependencies
+
+License:	MIT
+URL:		https://github.com/leamas/opencpn
+
+BuildRequires: binutils
+BuildRequires: cmake
+BuildRequires: gettext
+BuildRequires: git
+BuildRequires: make
+BuildRequires: mingw-binutils-generic
+BuildRequires: mingw-filesystem-base
+BuildRequires: mingw32-binutils
+BuildRequires: mingw32-filesystem
+BuildRequires: mingw32-fontconfig
+BuildRequires: mingw32-freetype
+BuildRequires: mingw32-gcc
+BuildRequires: mingw32-gcc-c++
+BuildRequires: mingw32-cpp
+BuildRequires: mingw32-gettext
+BuildRequires: mingw32-headers
+BuildRequires: mingw32-gtk2
+BuildRequires: mingw32-libffi
+BuildRequires: mingw32-libtiff
+BuildRequires: mingw32-nsiswrapper
+BuildRequires: mingw32-win-iconv
+BuildRequires: mingw32-wxWidgets3 >= 3.0.2
+
+%description
+
+Empty package used to catch build dependencies for opencpn plugins using
+the mingw tools to create a Windows 32-bit executable
+
+Use dnf builddep opencpn-deps.spec to install the dependencies.
+
+%prep
+
+
+%build
+
+
+%install
+
+
+%files
+%doc COPYING
+
+
+%changelog
+* Thu Jan 07 2021 Alec Leamas <leamas.alec@gmail.com> - 0.1-1
+- Initial release

--- a/update-templates
+++ b/update-templates
@@ -153,7 +153,6 @@ for f in \
     .drone.yml \
     .gitattributes \
     .gitignore \
-    flatpak/manifest.wx31.patch \
     INSTALL.md \
     plugin.xml.in \
     .travis.yml \


### PR DESCRIPTION
build-deps: restore directory after being removed in 1e48401015f, presumably by accident.

CircleCI build log [here](https://app.circleci.com/pipelines/github/leamas/radar_pi/137/workflows/cb6eb926-b8bc-4086-8653-efa4a498afbb)