### PR TITLE
Recognize the Navico model and stop offering Doppler, modes and ranges the radar does not have

### DIFF
--- a/CHANGELOG-PLUGIN.md
+++ b/CHANGELOG-PLUGIN.md
@@ -11,6 +11,10 @@ Sections can be: Added Changed Deprecated Removed Fixed Security.
 
 ## [Unreleased]
 
+### Added
+
+- Recognize the exact Navico model and read its capability report, so that Doppler, use modes and ranges that the radar does not have are no longer offered, as on the HALO 20 (#238, #203)
+
 ## [5.7.2]
 
 ### Fixed

--- a/Plugin.cmake
+++ b/Plugin.cmake
@@ -174,6 +174,7 @@ set(SRC
   src/garminxhd/GarminxHDControl.cpp
   src/garminxhd/GarminxHDControlsDialog.cpp
   src/garminxhd/GarminxHDReceive.cpp
+  src/navico/NavicoCapabilities.cpp
   src/navico/NavicoControl.cpp
   src/navico/NavicoControlsDialog.cpp
   src/navico/NavicoLocate.cpp

--- a/include/ControlsDialog.h
+++ b/include/ControlsDialog.h
@@ -460,6 +460,7 @@ protected:
     void SetMenuAutoHideTimeout();
     void SwitchTo(wxBoxSizer* to, const wxChar* name);
     bool UpdateSizersButtonsShown();
+    void LimitModesToSupported();
 
 public:
     void Resize(bool force);

--- a/include/RadarInfo.h
+++ b/include/RadarInfo.h
@@ -80,6 +80,11 @@ public:
     size_t m_spokes; // # of spokes per rotation
     size_t m_spoke_len_max; // Max # of bytes per spoke
     size_t m_no_transmit_zones;
+    bool m_doppler_supported; // Cleared when the radar says it has no Doppler
+    int m_max_range_meters; // Furthest range the radar says it can do, 0 =
+                            // unknown, then the table for its type is used
+    uint32_t m_supported_modes; // Bit n is set when the radar has mode n, see
+                                // CT_MODE. 0 = unknown, then all are offered
     int m_radar_ranges[21]; // Ranges actually in use (values displayed). Always
                             // in meters, also if units is NM. Currently only
                             // used for Raymarine.

--- a/include/navico/NavicoCapabilities.h
+++ b/include/navico/NavicoCapabilities.h
@@ -1,0 +1,109 @@
+/******************************************************************************
+ *
+ * Project:  OpenCPN
+ * Purpose:  Radar Plugin
+ * Author:   David Register
+ *           Dave Cowell
+ *           Kees Verruijt
+ *           Douwe Fokkema
+ *           Sean D'Epagnier
+ ***************************************************************************
+ *   Copyright (C) 2010 by David S. Register              bdbcat@yahoo.com *
+ *   Copyright (C) 2012-2013 by Dave Cowell                                *
+ *   Copyright (C) 2012-2025 by Kees Verruijt         canboat@verruijt.net *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************
+ */
+
+#ifndef _NAVICOCAPABILITIES_H_
+#define _NAVICOCAPABILITIES_H_
+
+#include "pi_common.h"
+
+PLUGIN_BEGIN_NAMESPACE
+
+//
+// The exact model, as reported in report 03 C4. This is how the chartplotters
+// tell a HALO 20 from a HALO 20+ or 24; nothing else in the protocol does.
+//
+enum NavicoScannerType {
+    NST_BR24 = 10,
+    NST_3G = 12,
+    NST_4G = 13,
+    NST_HALO = 14,
+    NST_HALO24 = 16,
+    NST_HALO20 = 17,
+    NST_HALO20PLUS = 18,
+    NST_HALO2000 = 19,
+    NST_HALO3000 = 20,
+    NST_HALO5000 = 21,
+    NST_HALO4000 = 22,
+    NST_HALO6000 = 23,
+};
+
+// Name of a scanner type for logging, "Unknown" when we don't know it.
+extern wxString NavicoScannerTypeName(uint32_t scanner_type);
+
+// False only for the models that we know cannot do Doppler.
+extern bool NavicoScannerHasDoppler(uint32_t scanner_type);
+
+//
+// The capabilities that a HALO radar advertises in report 09 C4.
+//
+// The 'supported use modes' bitmask has one bit per use mode, numbered the
+// same way as the mode values that the radar reports, so bit n means mode n.
+// The BR24, 3G and 4G never send this report.
+//
+class NavicoCapabilities {
+public:
+    NavicoCapabilities()
+        : m_valid(false)
+        , m_supported_modes(0)
+        , m_min_range_m(0)
+        , m_max_range_m(0)
+        , m_dome(true) {};
+
+    // Parse the TLV stream that follows the two byte report header.
+    // Returns false if the stream is malformed, in which case the object is
+    // left invalid.
+    bool Parse(const uint8_t* data, size_t len);
+
+    uint32_t GetMaxRangeMeters() const { return m_max_range_m; }
+    uint32_t GetSupportedModes() const { return m_supported_modes; }
+
+    bool operator==(const NavicoCapabilities& other) const
+    {
+        return m_valid == other.m_valid
+            && m_supported_modes == other.m_supported_modes
+            && m_min_range_m == other.m_min_range_m
+            && m_max_range_m == other.m_max_range_m
+            && m_dome == other.m_dome;
+    }
+
+    wxString to_string() const;
+
+private:
+    bool m_valid; // A report has been parsed successfully
+    uint32_t m_supported_modes; // Bit n is set when the radar has use mode n
+    uint32_t m_min_range_m; // Shortest instrumented range
+    uint32_t m_max_range_m; // Longest instrumented range
+    bool m_dome; // Dome antenna, else open array
+};
+
+PLUGIN_END_NAMESPACE
+
+#endif /* _NAVICOCAPABILITIES_H_ */

--- a/include/navico/NavicoReceive.h
+++ b/include/navico/NavicoReceive.h
@@ -35,6 +35,7 @@
 
 #include "NavicoCommon.h"
 #include "RadarReceive.h"
+#include "navico/NavicoCapabilities.h"
 #include "navico/NavicoLocate.h"
 #include "socketutil.h"
 
@@ -81,6 +82,7 @@ public:
         m_halo_sent_mystery = m_halo_received_info;
         m_halo_sent_speed = m_halo_received_info;
         m_hours = 0;
+        m_scanner_type = 0;
 
         m_receive_socket = GetLocalhostServerTCPSocket();
         m_send_socket = GetLocalhostSendTCPSocket(m_receive_socket);
@@ -135,6 +137,7 @@ private:
     SOCKET GetNewReportSocket();
     SOCKET PickNextEthernetCard();
     bool ProcessReport(const uint8_t* data, size_t len);
+    void ProcessCapabilities(const uint8_t* data, size_t len);
     void DetectedRadar(NetworkAddress& radar_address);
     void ProcessFrame(const uint8_t* data, size_t len);
     void ReleaseInfoSocket();
@@ -162,6 +165,8 @@ private:
     wxString m_status; // Userfriendly string
     wxString m_firmware; // Userfriendly string #2
     uint32_t m_hours; // Number of hours transmitted
+    uint32_t m_scanner_type; // Which exact model this is, see NavicoScannerType
+    NavicoCapabilities m_capabilities; // What the radar says it can do
 
     void SetInfoStatus(wxString status)
     {

--- a/src/ControlsDialog.cpp
+++ b/src/ControlsDialog.cpp
@@ -1800,6 +1800,19 @@ bool ControlsDialog::UpdateSizersButtonsShown() {
     }
   }
 
+  // Radars such as the HALO 20 have Doppler buttons in their control set but
+  // report that they do not support it.
+  if (m_top_sizer->IsShown(m_view_sizer)) {
+    if (m_doppler_button && m_view_sizer->IsShown(m_doppler_button) != m_ri->m_doppler_supported) {
+      m_view_sizer->Show(m_doppler_button, m_ri->m_doppler_supported);
+      resize = true;
+    }
+    if (m_doppler_threshold_button && m_view_sizer->IsShown(m_doppler_threshold_button) != m_ri->m_doppler_supported) {
+      m_view_sizer->Show(m_doppler_threshold_button, m_ri->m_doppler_supported);
+      resize = true;
+    }
+  }
+
   for (int i = 0; i < CANVAS_COUNT; i++) {
     if (m_top_sizer->IsShown(m_window_sizer) && !m_window_sizer->IsShown(m_overlay_button[i])) {
       m_window_sizer->Show(m_overlay_button[i]);
@@ -2176,6 +2189,26 @@ void ControlsDialog::LimitRadarControls() {
   }
 }
 
+//
+// Drop the modes that the radar says it does not have. A blank name is how a
+// mode is left out of the button, the same way that Buoy always is.
+//
+void ControlsDialog::LimitModesToSupported() {
+  ControlInfo& ci = m_ctrl[CT_MODE];
+
+  if (m_ri->m_supported_modes == 0 || !ci.names) {
+    return;
+  }
+  for (int mode = ci.minValue; mode <= ci.maxValue; mode++) {
+    if ((m_ri->m_supported_modes & (1 << mode)) == 0) {
+      ci.names[mode] = wxT("");
+    }
+  }
+  while (ci.maxValue > ci.minValue && ci.names[ci.maxValue].length() == 0) {
+    ci.maxValue--;
+  }
+}
+
 void ControlsDialog::UpdateControlValues(bool refreshAll) {
   wxString o;
   bool updateEditDialog = false;
@@ -2282,6 +2315,7 @@ void ControlsDialog::UpdateControlValues(bool refreshAll) {
 
   //   mode (RM_Quantum)
   if (m_mode_button) {
+    LimitModesToSupported();
     m_mode_button->UpdateLabel();
   }
 

--- a/src/RadarFactory.cpp
+++ b/src/RadarFactory.cpp
@@ -212,6 +212,14 @@ size_t RadarFactory::GetRadarRanges(RadarInfo* ri, RangeUnits units, const int**
                (int)units);
     wxAbort();
   }
+
+  // Some radars, such as the HALO 20, see less far than the largest range in
+  // the table for their type. Once the radar has told us how far it reaches
+  // we drop the ranges that it cannot do.
+  while (n > 1 && ri->m_max_range_meters > 0 && (*ranges)[n - 1] > ri->m_max_range_meters) {
+    n--;
+  }
+
   return n;
 }
 

--- a/src/RadarInfo.cpp
+++ b/src/RadarInfo.cpp
@@ -92,6 +92,9 @@ RadarInfo::RadarInfo(radar_pi *pi, int radar) {
   m_last_rotation_time = 0;
   m_last_angle = 0;
   m_no_transmit_zones = 0;
+  m_doppler_supported = true;
+  m_max_range_meters = 0;
+  m_supported_modes = 0;
   for (int i = 0; i < MAX_CHART_CANVAS; i++) {
       m_start_overlay_r[i] = 0;
     }

--- a/src/navico/NavicoCapabilities.cpp
+++ b/src/navico/NavicoCapabilities.cpp
@@ -1,0 +1,157 @@
+/******************************************************************************
+ *
+ * Project:  OpenCPN
+ * Purpose:  Radar Plugin
+ * Author:   David Register
+ *           Dave Cowell
+ *           Kees Verruijt
+ *           Douwe Fokkema
+ *           Sean D'Epagnier
+ ***************************************************************************
+ *   Copyright (C) 2010 by David S. Register              bdbcat@yahoo.com *
+ *   Copyright (C) 2012-2013 by Dave Cowell                                *
+ *   Copyright (C) 2012-2025 by Kees Verruijt         canboat@verruijt.net *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************
+ */
+
+#include "navico/NavicoCapabilities.h"
+
+#include "radar_pi.h"
+
+PLUGIN_BEGIN_NAMESPACE
+
+/*
+ * Report 09 C4 is a list of TLV entries, each headed by a type byte, a
+ * reserved byte and a length byte. Only HALO radars send it.
+ *
+ * The types below are the ones that we act upon. The radar sends many more,
+ * up to type 67 on recent firmware, but even the Navico MFD software that we
+ * have seen only understands types 2 to 12.
+ */
+#define TLV_HEADER_LEN (3)
+
+#define TLV_SUPPORTED_USE_MODES (2)  // Bit n set = the radar has use mode n
+#define TLV_SUPPORTED_ANTENNAS (10)  // Dome or list of open array sizes
+#define TLV_INSTRUMENTED_RANGE (11)  // Min and max range in decimeters
+
+#define DECIMETERS_PER_METER (10)
+
+// Indexed by use mode, so also by the bit number in the supported modes mask.
+static const wxString ModeNames[] = {wxT("Custom"), wxT("Harbor"), wxT("Offshore"),
+                                     wxT("Buoy"),   wxT("Weather"), wxT("Bird")};
+
+wxString NavicoScannerTypeName(uint32_t scanner_type) {
+  switch (scanner_type) {
+    case NST_BR24:
+      return wxT("BR24");
+    case NST_3G:
+      return wxT("3G");
+    case NST_4G:
+      return wxT("4G");
+    case NST_HALO:
+      return wxT("HALO");
+    case NST_HALO24:
+      return wxT("HALO24");
+    case NST_HALO20:
+      return wxT("HALO20");
+    case NST_HALO20PLUS:
+      return wxT("HALO20+");
+    case NST_HALO2000:
+      return wxT("HALO2000");
+    case NST_HALO3000:
+      return wxT("HALO3000");
+    case NST_HALO5000:
+      return wxT("HALO5000");
+    case NST_HALO4000:
+      return wxT("HALO4000");
+    case NST_HALO6000:
+      return wxT("HALO6000");
+    default:
+      return wxT("Unknown");
+  }
+}
+
+bool NavicoScannerHasDoppler(uint32_t scanner_type) {
+  // The HALO 20 is the small brother of the HALO 20+; it has no Doppler where
+  // every other HALO that we know of has. Assume that an unknown model has it,
+  // that is what the plugin has always done.
+  return scanner_type != NST_HALO20;
+}
+
+static uint32_t GetUInt32LE(const uint8_t *p) {
+  return (uint32_t)p[0] | ((uint32_t)p[1] << 8) | ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+}
+
+bool NavicoCapabilities::Parse(const uint8_t *data, size_t len) {
+  size_t offset = 0;
+
+  while (offset + TLV_HEADER_LEN <= len) {
+    uint8_t type = data[offset];
+    size_t length = data[offset + 2];
+    const uint8_t *payload = data + offset + TLV_HEADER_LEN;
+
+    offset += TLV_HEADER_LEN + length;
+    if (offset > len) {
+      LOG_RECEIVE(wxT("capability report truncated in type %u at offset %u of %u"), type, (unsigned)offset, (unsigned)len);
+      return false;
+    }
+
+    switch (type) {
+      case TLV_SUPPORTED_USE_MODES: {
+        if (length >= 4) {
+          m_supported_modes = GetUInt32LE(payload);
+        }
+        break;
+      }
+
+      case TLV_SUPPORTED_ANTENNAS: {
+        // A dome sends a single zero byte, an open array the sizes it supports
+        m_dome = (length == 1 && payload[0] == 0);
+        break;
+      }
+
+      case TLV_INSTRUMENTED_RANGE: {
+        if (length >= 8) {
+          m_min_range_m = GetUInt32LE(payload) / DECIMETERS_PER_METER;
+          m_max_range_m = GetUInt32LE(payload + 4) / DECIMETERS_PER_METER;
+        }
+        break;
+      }
+    }
+  }
+
+  m_valid = true;
+  return true;
+}
+
+wxString NavicoCapabilities::to_string() const {
+  wxString s;
+
+  s << wxT("modes=");
+  for (size_t mode = 0; mode < ARRAY_SIZE(ModeNames); mode++) {
+    if (m_supported_modes & (1 << mode)) {
+      s << ModeNames[mode] << wxT(",");
+    }
+  }
+  s << wxString::Format(wxT(" range=%u-%um antenna=%s"), m_min_range_m, m_max_range_m,
+                        m_dome ? wxT("dome") : wxT("open array"));
+
+  return s;
+}
+
+PLUGIN_END_NAMESPACE

--- a/src/navico/NavicoReceive.cpp
+++ b/src/navico/NavicoReceive.cpp
@@ -1034,9 +1034,10 @@ struct RadarReport_02C4_99 {       // length 99
 struct RadarReport_03C4_129 {
   uint8_t what;
   uint8_t command;
-  uint8_t radar_type;  // I hope! 01 = 4G and new 3G, 08 = 3G, 0F = BR24, 00 = HALO
-  uint8_t u00[31];     // Lots of unknown
-  uint32_t hours;      // Hours of operation
+  uint8_t radar_type;     // I hope! 01 = 4G and new 3G, 08 = 3G, 0F = BR24, 00 = HALO
+  uint8_t u00[27];        // Lots of unknown
+  uint32_t scanner_type;  // 30-33 The exact model, see NavicoScannerType
+  uint32_t hours;         // Hours of operation
   uint8_t u01[20];     // Lots of unknown
   uint16_t firmware_date[16];
   uint16_t firmware_time[16];
@@ -1174,6 +1175,13 @@ bool NavicoReceive::ProcessReport(const uint8_t *report, size_t len) {
   LOG_BINARY_REPORTS(wxString::Format(wxT("%s report"), m_ri->m_name.c_str()), report, len);
 
   if (report[1] == 0xC4) {
+    if (report[0] == 0x09 && len > 2) {
+      // The capability report grows with every firmware version, so it cannot
+      // be part of the length based switch below.
+      ProcessCapabilities(report + 2, len - 2);
+      return true;
+    }
+
     // Looks like a radar report. Is it a known one?
     switch ((len << 8) + report[0]) {
       case (18 << 8) + 0x01: {  //  length 18, 01 C4
@@ -1241,7 +1249,22 @@ bool NavicoReceive::ProcessReport(const uint8_t *report, size_t len) {
 
       case (129 << 8) + 0x03: {  // 129 bytes starting with 03 C4
         RadarReport_03C4_129 *s = (RadarReport_03C4_129 *)report;
-        LOG_RECEIVE(wxT("%s RadarReport_03C4_129 radar_type=%u hours=%u"), m_ri->m_name.c_str(), s->radar_type, s->hours);
+        LOG_RECEIVE(wxT("%s RadarReport_03C4_129 radar_type=%u scanner_type=%u hours=%u"), m_ri->m_name.c_str(), s->radar_type,
+                    s->scanner_type, s->hours);
+
+        if (s->scanner_type != m_scanner_type) {
+          m_scanner_type = s->scanner_type;
+          LOG_INFO(wxT("%s is a %s (scanner type %u)"), m_ri->m_name.c_str(), NavicoScannerTypeName(m_scanner_type).c_str(),
+                   m_scanner_type);
+
+          m_ri->m_doppler_supported = NavicoScannerHasDoppler(m_scanner_type);
+          if (!m_ri->m_doppler_supported) {
+            m_ri->m_doppler.Update(0);
+            if (m_ri->m_doppler.IsModified()) {
+              m_ri->ComputeColourMap();
+            }
+          }
+        }
 
         wxString ts;
 
@@ -1438,6 +1461,22 @@ bool NavicoReceive::ProcessReport(const uint8_t *report, size_t len) {
     LOG_BINARY_RECEIVE(wxT("received unknown message"), report, len);
   }
   return false;
+}
+
+//
+// A HALO tells us which use modes it has and how far it can see.
+//
+void NavicoReceive::ProcessCapabilities(const uint8_t *report, size_t len) {
+  NavicoCapabilities capabilities;
+
+  if (!capabilities.Parse(report, len) || capabilities == m_capabilities) {
+    return;
+  }
+  m_capabilities = capabilities;
+  LOG_INFO(wxT("%s capabilities: %s"), m_ri->m_name.c_str(), capabilities.to_string().c_str());
+
+  m_ri->m_max_range_meters = (int)capabilities.GetMaxRangeMeters();
+  m_ri->m_supported_modes = capabilities.GetSupportedModes();
 }
 
 // Called from the main thread to stop this thread.


### PR DESCRIPTION
A HALO 20 is offered Doppler, Bird mode and ranges up to 72 NM even though it
has none of them. Enabling Doppler on one appears to work but produces
nonsense: every nibble reads as "approaching", painting the whole marina
yellow.

**Model identification.** Report `03 C4` carries an `eScannerType` at bytes
30–33 that names the exact model. This is how the chartplotters tell a HALO 20
from a HALO 20+ or 24, and nothing else in the protocol does it — the field sat
inside a block the plugin treated as unknown. Doppler is now gated on the
model.

**Capabilities.** HALO radars separately advertise their use modes and
instrumented range in report `09 C4`, a TLV encoded capability list. The mode
mask has one bit per use mode, numbered the same as the mode values the radar
reports. Unsupported modes are dropped from the mode button and unreachable
ranges from the range list.

| Capture | scanner_type | Modes | Max range |
|---|---|---|---|
| HALO 20 | 17 = Halo20 | Custom, Harbor, Offshore, Weather | 24 NM |
| HALO 20+ | 18 = Halo20+ | + Bird | 36 NM |
| HALO 24 | 16 = Halo24 | + Bird | 48 NM |
| HALO 3006 | 20 = Halo3000 | + Bird | 96 NM, open array |
| 4G | 13 = 4G | — | 36 NM |
| BR24 | 10 = BR24 | — | 24 NM |

Verified against captures of all six. The TLV parse consumes each packet
exactly, with no bytes left over, and every use mode observed on the wire has
its bit set in that radar's mask. BR24, 3G and 4G never send the capability
report and are unaffected, as is any HALO until its reports arrive.

Only the HALO 20 is treated as having no Doppler; every other model keeps
today's behaviour, including models we have no capture of.

Metric users of a HALO 20 will notice that the range list now stops at 36 km
rather than 48 km, which is correct as the radar reaches 44.4 km.

closes #238
closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)