### PR TITLE
Add support for HALO 24 with 2025 firmware

### DIFF
--- a/CHANGELOG-PLUGIN.md
+++ b/CHANGELOG-PLUGIN.md
@@ -15,6 +15,10 @@ Sections can be: Added Changed Deprecated Removed Fixed Security.
 
 - Recognize the exact Navico model and read its capability report, so that Doppler, use modes and ranges that the radar does not have are no longer offered, as on the HALO 20 (#238, #203)
 
+### Fixed
+
+- Doppler, sea state, scan speed and other settings stayed at their startup value on a HALO 24 with 2025 firmware, which sends a longer status report than we recognized (#300)
+
 ## [5.7.2]
 
 ### Fixed

--- a/src/navico/NavicoReceive.cpp
+++ b/src/navico/NavicoReceive.cpp
@@ -1347,6 +1347,7 @@ bool NavicoReceive::ProcessReport(const uint8_t *report, size_t len) {
         /* Over time we have seen this report with 3 various lengths!!
          */
 
+      case (32 << 8) + 0x08:    // FALLTHRU HALO 24 with 2025 firmware
       case (24 << 8) + 0x08:    // FALLTHRU HALO 2000
       case (22 << 8) + 0x08:    // FALLTHRU
       case (21 << 8) + 0x08: {  // length 21, 08 C4


### PR DESCRIPTION
A HALO 24 on 2025 firmware sends its `08 C4` status report as 32 bytes. The
plugin only recognized lengths 18, 21, 22 and 24, so the report fell through to
`default:` and was discarded. Every setting it carries then kept whatever value
it started with: Doppler and its speed threshold, sea state, sea clutter, scan
speed, noise rejection, target separation, sidelobe suppression and local
interference rejection.

Doppler is the one users notice, because unlike the others it is not saved in
the ini file. It starts at Off and, with the report dropped, nothing ever
corrects it — exactly the report in #300.

The longer report has the same layout with the extra bytes at the end, so it
joins the existing fall through. The handler casts to `RadarReport_08C4_21`,
which reads bytes 0–20 only.

It is firmware dependent, which is why not every HALO 24 shows it:

| Capture | scanner type | `08 C4` length |
|---|---|---|
| halo24_and_0183 | Halo24 | 22 |
| antenna-offset | Halo24 | 22 |
| sea_clutter_halo | Halo24 | **32** |
| halo24-with-mayara (Oct 2025 fw) | Halo24 | **32** |

Verified against those captures: `doppler_state` and the other fields sit at
the same offsets in the 32 byte variant and carry live values.

closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)